### PR TITLE
Add methods for http statuses: 502, 503 and 504

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ func main() {
 | 422 | UnprocessableEntity() |
 | 500 | InternalServerError() |
 | 501 | NotImplemented() |
+| 502 | BadGateway() |
+| 503 | ServiceUnavailable() |
+| 504 | GatewayTimeout() |
 
 See [here](https://httpstatuses.com/) for a complete list of HTTP responses, along with an explanation of each.
 

--- a/error.go
+++ b/error.go
@@ -56,3 +56,18 @@ func (resp *Response) InternalServerError(v interface{}) {
 func (resp *Response) NotImplemented(v interface{}) {
 	resp.writeResponse(http.StatusNotImplemented, v)
 }
+
+// BadGateway returns a 502 Bad Gateway JSON response
+func (resp *Response) BadGateway(v interface{}) {
+	resp.writeResponse(http.StatusBadGateway, v)
+}
+
+// ServiceUnavailable returns a 503 Service Unavailable JSON response
+func (resp *Response) ServiceUnavailable(v interface{}) {
+	resp.writeResponse(http.StatusServiceUnavailable, v)
+}
+
+// GatewayTimeout returns a 504 Gateway Timeout JSON response
+func (resp *Response) GatewayTimeout(v interface{}) {
+	resp.writeResponse(http.StatusGatewayTimeout, v)
+}

--- a/error_test.go
+++ b/error_test.go
@@ -284,8 +284,10 @@ var testData = []struct {
 
 func TestErrorResponses(t *testing.T) {
 	for _, datum := range testData {
+		datum := datum
 		t.Run(datum.testName, func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
+
 			req := newRequest(t, datum.inputHttpVerb)
 
 			rr := httptest.NewRecorder()


### PR DESCRIPTION
This PR includes three new methods for statuses: 502, 503 and 504.
I've also reworked code of unit test to table driven style but I haven't changed old code and used only for newly added methods to make this PR minimal and easy to review and merge.