### PR TITLE
Add support for HTTP statuses 413 and 415

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ func main() {
 | 409 | Conflict() |
 | 411 | LengthRequired() |
 | 412 | PreconditionFailed() |
+| 413 | RequestEntityTooLarge() |
+| 415 | UnsupportedMediaType() |
 | 422 | UnprocessableEntity() |
 | 500 | InternalServerError() |
 | 501 | NotImplemented() |

--- a/error.go
+++ b/error.go
@@ -42,6 +42,11 @@ func (resp *Response) PreconditionFailed(v interface{}) {
 	resp.writeResponse(http.StatusPreconditionFailed, v)
 }
 
+// UnsupportedMediaType returns a 415 Unsupported Media Type JSON response
+func (resp *Response) UnsupportedMediaType(v interface{}) {
+	resp.writeResponse(http.StatusUnsupportedMediaType, v)
+}
+
 // UnprocessableEntity returns a 422 Unprocessable Entity JSON response
 func (resp *Response) UnprocessableEntity(v interface{}) {
 	resp.writeResponse(http.StatusUnprocessableEntity, v)

--- a/error.go
+++ b/error.go
@@ -42,6 +42,11 @@ func (resp *Response) PreconditionFailed(v interface{}) {
 	resp.writeResponse(http.StatusPreconditionFailed, v)
 }
 
+// RequestEntityTooLarge returns a 413 Request Entity Too Large JSON response
+func (resp *Response) RequestEntityTooLarge(v interface{}) {
+	resp.writeResponse(http.StatusRequestEntityTooLarge, v)
+}
+
 // UnsupportedMediaType returns a 415 Unsupported Media Type JSON response
 func (resp *Response) UnsupportedMediaType(v interface{}) {
 	resp.writeResponse(http.StatusUnsupportedMediaType, v)

--- a/error_test.go
+++ b/error_test.go
@@ -187,6 +187,28 @@ func TestPreconditionFailed(t *testing.T) {
 	}
 }
 
+func TestUnsupportedMediaType(t *testing.T) {
+	t.Parallel()
+
+	req := newRequest(t, "POST")
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := NewResponse(w)
+		res.UnsupportedMediaType(&Error{415, "Unsupported Media Type"})
+	})
+	handler.ServeHTTP(rr, req)
+
+	if err := validateStatusCode(rr.Code, http.StatusUnsupportedMediaType); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	expected := `{"code":415,"message":"Unsupported Media Type"}`
+	if err := validateResponseBody(rr.Body.String(), expected); err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
 func TestUnprocessableEntity(t *testing.T) {
 	t.Parallel()
 

--- a/error_test.go
+++ b/error_test.go
@@ -187,6 +187,28 @@ func TestPreconditionFailed(t *testing.T) {
 	}
 }
 
+func TestRequestEntityTooLarge(t *testing.T) {
+	t.Parallel()
+
+	req := newRequest(t, "POST")
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := NewResponse(w)
+		res.RequestEntityTooLarge(&Error{413, "Payload too large"})
+	})
+	handler.ServeHTTP(rr, req)
+
+	if err := validateStatusCode(rr.Code, http.StatusRequestEntityTooLarge); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	expected := `{"code":413,"message":"Payload too large"}`
+	if err := validateResponseBody(rr.Body.String(), expected); err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
 func TestUnsupportedMediaType(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Implements 2 new HTTP statuses (413 & 415) (along with the unit tests), I would be happy to have included in that lib. :wink: 

Thanks.